### PR TITLE
DM-36766: Add `butler obscore-update-table` CLI command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   build_and_test:
-    # runs-on: ubuntu-latest
-    # Need >= 20.04 for modern sqlite. Can switch to latest when
-    # github change
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -20,7 +21,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: "3.10"
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,4 +1,4 @@
-name: check Python formatting
+name: Check Python formatting
 
 on:
   push:
@@ -7,22 +7,5 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.8
-          cache: "pip"
-
-      - name: Install isort and black
-        run: pip install isort black
-
-      - name: Run isort
-        run: isort --check-only --diff python/ tests/
-
-      - name: Run black
-        run: black --check --verbose --diff python/ tests/
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/formatting.yaml@main

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,19 +7,5 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.8
-          cache: "pip"
-
-      - name: Install
-        run: pip install -r <(curl https://raw.githubusercontent.com/lsst/linting/main/requirements.txt)
-
-      - name: Run linter
-        run: flake8
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/lint.yaml@main

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -7,33 +7,5 @@ on:
   pull_request:
 
 jobs:
-  mypy:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.8
-          cache: "pip"
-          cache-dependency-path: "setup.cfg"
-
-      - name: Install
-        run: pip install mypy pydantic
-
-      - name: Install third party stubs
-        run: pip install types-requests types-PyYAML types-click types-pkg_resources types-Deprecated
-
-      - name: Install lsst dependencies
-        run: |
-          pip install -r requirements.txt
-
-      - name: Fake a version
-        run: |
-          echo "__all__ = ['__version__']" > python/lsst/dax/obscore/version.py
-          echo "__version__ = '0.0.1'" >> python/lsst/dax/obscore/version.py
-
-      - name: Change to source directory and run mypy
-        run: mypy python/lsst
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -7,19 +7,5 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.8
-          cache: "pip"
-
-      - name: Install
-        run: pip install yamllint
-
-      - name: Run linter
-        run: yamllint .
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/yamllint.yaml@main

--- a/python/lsst/dax/obscore/cli/cmd/__init__.py
+++ b/python/lsst/dax/obscore/cli/cmd/__init__.py
@@ -21,4 +21,4 @@
 
 __all__ = ["obscore_export", "obscore_set_exposure_regions"]
 
-from .commands import obscore_export, obscore_set_exposure_regions
+from .commands import obscore_export, obscore_set_exposure_regions, obscore_update_table

--- a/python/lsst/dax/obscore/cli/cmd/__init__.py
+++ b/python/lsst/dax/obscore/cli/cmd/__init__.py
@@ -19,6 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["obscore_export", "obscore_set_exposure_regions"]
+__all__ = ["obscore"]
 
-from .commands import obscore_export, obscore_set_exposure_regions, obscore_update_table
+from .commands import obscore

--- a/python/lsst/dax/obscore/cli/cmd/commands.py
+++ b/python/lsst/dax/obscore/cli/cmd/commands.py
@@ -35,7 +35,13 @@ from lsst.daf.butler.cli.utils import ButlerCommand, MWPath, split_commas
 from ... import script
 
 
-@click.command(
+@click.group(short_help="Commands to export or update obscore data.")
+def obscore() -> None:
+    """Set of commands to deal with obscore data."""
+    pass
+
+
+@obscore.command(
     short_help="Export Butler datasets as ObsCore Data Model",
     cls=ButlerCommand,
 )
@@ -66,12 +72,12 @@ from ... import script
 @collections_option()
 @where_option()
 @options_file_option()
-def obscore_export(*args: Any, **kwargs: Any) -> None:
+def export(*args: Any, **kwargs: Any) -> None:
     """Export Butler datasets as ObsCore Data Model in parquet format."""
     script.obscore_export(*args, **kwargs)
 
 
-@click.command(
+@obscore.command(
     short_help=(
         "Udpate exposure-related records (e.g. raw) in obscore table that do not have region information "
         "from matching visit-related records."
@@ -115,14 +121,14 @@ def obscore_export(*args: Any, **kwargs: Any) -> None:
     callback=split_commas,
     default=("s_region", "s_ra", "s_dec", "s_fov"),
 )
-def obscore_set_exposure_regions(*args: Any, **kwargs: Any) -> None:
+def set_exposure_regions(*args: Any, **kwargs: Any) -> None:
     """Update exposure-related records (e.g. raw) in obscore table that do not
     have region information from matching visit-related records.
     """
     script.obscore_set_exposure_regions(*args, **kwargs)
 
 
-@click.command(
+@obscore.command(
     short_help=(
         "Update obscore table with the records that are missing, typically "
         "used after adding obscore support to existing repository."
@@ -131,7 +137,7 @@ def obscore_set_exposure_regions(*args: Any, **kwargs: Any) -> None:
 )
 @repo_argument(required=True)
 @click.option("--dry-run", help="Skip actual update, but execute all other queries.", is_flag=True)
-def obscore_update_table(*args: Any, **kwargs: Any) -> None:
+def update_table(*args: Any, **kwargs: Any) -> None:
     """Update obscore table with the records that are missing, typically
     used after adding obscore support to existing repository.
     """

--- a/python/lsst/dax/obscore/cli/cmd/commands.py
+++ b/python/lsst/dax/obscore/cli/cmd/commands.py
@@ -120,3 +120,19 @@ def obscore_set_exposure_regions(*args: Any, **kwargs: Any) -> None:
     have region information from matching visit-related records.
     """
     script.obscore_set_exposure_regions(*args, **kwargs)
+
+
+@click.command(
+    short_help=(
+        "Update obscore table with the records that are missing, typically "
+        "used after adding obscore support to existing repository."
+    ),
+    cls=ButlerCommand,
+)
+@repo_argument(required=True)
+@click.option("--dry-run", help="Skip actual update, but execute all other queries.", is_flag=True)
+def obscore_update_table(*args: Any, **kwargs: Any) -> None:
+    """Update obscore table with the records that are missing, typically
+    used after adding obscore support to existing repository.
+    """
+    script.obscore_update_table(*args, **kwargs)

--- a/python/lsst/dax/obscore/cli/resources.yaml
+++ b/python/lsst/dax/obscore/cli/resources.yaml
@@ -1,6 +1,4 @@
 cmd:
   import: lsst.dax.obscore.cli.cmd
   commands:
-    - obscore-export
-    - obscore-set-exposure-regions
-    - obscore-update-table
+    - obscore

--- a/python/lsst/dax/obscore/cli/resources.yaml
+++ b/python/lsst/dax/obscore/cli/resources.yaml
@@ -3,3 +3,4 @@ cmd:
   commands:
     - obscore-export
     - obscore-set-exposure-regions
+    - obscore-update-table

--- a/python/lsst/dax/obscore/script/__init__.py
+++ b/python/lsst/dax/obscore/script/__init__.py
@@ -21,3 +21,4 @@
 
 from .obscore_export import obscore_export
 from .obscore_set_exposure_regions import obscore_set_exposure_regions
+from .obscore_update_table import obscore_update_table

--- a/python/lsst/dax/obscore/script/obscore_update_table.py
+++ b/python/lsst/dax/obscore/script/obscore_update_table.py
@@ -1,0 +1,132 @@
+# This file is part of dax_obscore.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ["obscore_update_table"]
+
+import logging
+import re
+import time
+from collections.abc import Iterator
+from typing import Any
+
+from lsst.daf.butler import Butler, CollectionType, DatasetType
+from lsst.daf.butler.registries.sql import SqlRegistry
+from lsst.daf.butler.registry.interfaces import CollectionRecord
+from lsst.daf.butler.registry.obscore import (
+    ConfigCollectionType,
+    ObsCoreLiveTableManager,
+    ObsCoreManagerConfig,
+)
+from lsst.utils import iteration
+
+_LOG = logging.getLogger(__name__)
+
+
+def obscore_update_table(
+    repo: str,
+    dry_run: bool,
+) -> None:
+    """Update obscore table with the records that are missing, typically
+    used after adding obscore support to existing repository.
+
+    Parameters
+    ----------
+    repo : `str`
+        URI to the butler repository.
+    dry_run : `bool`
+        If `True` then print the records that will be added, but do not
+        actually add them.
+    """
+
+    butler = Butler(repo, writeable=True)
+
+    # There is no client API for updating obscore table, so we need to access
+    # internals of the Registry and obscore manager.
+    registry = butler.registry
+    assert isinstance(registry, SqlRegistry), "Registry must be SqlRegistry"
+    manager = registry._managers.obscore
+    assert manager is not None, "Registry is not configured for obscore support"
+    assert isinstance(manager, ObsCoreLiveTableManager), f"Unexpected type of obscore manager {type(manager)}"
+    config = manager.config
+
+    for collection_record, dataset_type in _collections(registry, config):
+        start_time = time.time()
+        refs = registry.queryDatasets(dataset_type, collections=collection_record.name).expanded()
+        if dry_run:
+            for ref in refs:
+                _LOG.info("Will be adding dataset %s", ref)
+        else:
+            count = 0
+            if collection_record.type is CollectionType.RUN:
+                # Limit record number in single insert.
+                for refs_chunk in iteration.chunk_iterable(refs):
+                    count += manager.add_datasets(refs_chunk)
+            elif collection_record.type is CollectionType.TAGGED:
+                for refs_chunk in iteration.chunk_iterable(refs):
+                    count += manager.associate(refs_chunk, collection_record)
+            else:
+                raise ValueError(f"Unexpected collection type: {collection_record.type}")
+            end_time = time.time()
+            _LOG.info(
+                "Added %s records for dataset type %r and collection %r in %.0f seconds",
+                count,
+                dataset_type.name,
+                collection_record.name,
+                end_time - start_time,
+            )
+
+
+def _collections(
+    registry: SqlRegistry, config: ObsCoreManagerConfig
+) -> Iterator[tuple[CollectionRecord, DatasetType]]:
+    """Generate list of collections and dataset types to search for dataset
+    references.
+
+    Yield
+    -----
+    collection_record : `CollectionRecord`
+        Record for a collection to search.
+    dataset_type : `DatasetType`
+        Dataset type to search.
+    """
+
+    dataset_types = list(registry.queryDatasetTypes(config.dataset_types.keys()))
+    _LOG.info("Found these dataset types in registry: %s", [ds.name for ds in dataset_types])
+
+    collections: Any
+    if config.collection_type is ConfigCollectionType.RUN:
+        collection_type = CollectionType.RUN
+        if config.collections is None:
+            collections = ...
+        else:
+            collections = [re.compile(collection) for collection in config.collections]
+    elif config.collection_type is ConfigCollectionType.TAGGED:
+        collection_type = CollectionType.TAGGED
+        collections = config.collections
+    else:
+        raise ValueError(f"Unexpected collection type: {config.collection_type}")
+
+    for dataset_type in dataset_types:
+        for collection in registry.queryCollections(
+            collections, datasetType=dataset_type, collectionTypes=collection_type
+        ):
+            collection_record = registry._managers.collections.find(collection)
+            yield collection_record, dataset_type

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyarrow
 pyyaml
 pydantic
 git+https://github.com/lsst/sphgeom@main#egg=lsst-sphgeom
-git+https://github.com/lsst/daf_butler@main#egg=lsst-daf-butler
+git+https://github.com/lsst/daf_butler@tickets/DM-36766#egg=lsst-daf-butler


### PR DESCRIPTION
This command is used to fill obscore table with pre-existing data after obscore manager and its configuration is added to registry by schema migration scripts.