### PR TITLE
DM-37771: Update dax_obscore for changes in daf_butlerAPI

### DIFF
--- a/python/lsst/dax/obscore/config.py
+++ b/python/lsst/dax/obscore/config.py
@@ -23,15 +23,13 @@ from __future__ import annotations
 
 __all__ = ["ExporterConfig"]
 
-from typing import Optional
-
 from lsst.daf.butler.registry.obscore import ObsCoreConfig
 
 
 class ExporterConfig(ObsCoreConfig):
     """Complete configuration for ObscoreExporter."""
 
-    where: Optional[str] = None
+    where: str = ""
     """User expression to restrict the output. This value can be overridden
     with command line options.
     """

--- a/python/lsst/dax/obscore/script/obscore_set_exposure_regions.py
+++ b/python/lsst/dax/obscore/script/obscore_set_exposure_regions.py
@@ -115,8 +115,8 @@ def obscore_set_exposure_regions(
     def _count_missing() -> int:
         """Return count of records with missing region data."""
         query = sqlalchemy.select(sqlalchemy.func.count()).select_from(obscore_table).where(missing_where)
-        result = db.query(query)
-        return result.scalar()
+        with db.query(query) as result:
+            return result.scalar_one()
 
     if check:
         # Just print count and stop here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click
 pyarrow
 pyyaml
 pydantic
+sqlalchemy >= 1.4, < 2
 git+https://github.com/lsst/sphgeom@main#egg=lsst-sphgeom
 git+https://github.com/lsst/daf_relation@main#egg=lsst-daf-relation
 git+https://github.com/lsst/daf_butler@main#egg=lsst-daf-butler

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ pyarrow
 pyyaml
 pydantic
 git+https://github.com/lsst/sphgeom@main#egg=lsst-sphgeom
+git+https://github.com/lsst/daf_relation@main#egg=lsst-daf-relation
 git+https://github.com/lsst/daf_butler@main#egg=lsst-daf-butler
+git+https://github.com/lsst/utils@main#egg=lsst-utils


### PR DESCRIPTION
With the introduction of daf_relation, some of daf_butler interfaces have changed, in paticular few obscore manager methods now take QueryContext instance. This change makes that context instance and passes it to the methods that need it.