### PR TITLE
DM-38192: Update call to Database.query method

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Also this was the first reasonable test for `set-exposure-regions` command and I noticed that it is rather slow, as it called registry `queryDimensionRecords` method for each individual record. So I batched these calls to retrieve records for multiple exposures or visits in one call. This runs much faster now.