### PR TITLE
DM-40282: Update `configs/usdf-embargo-live.yaml` to reflect USDF configuration.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -15,7 +15,7 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/configs/usdf-embargo-live.yaml
+++ b/configs/usdf-embargo-live.yaml
@@ -18,7 +18,7 @@ dataset_types:
     o_ucd: phot.count
     access_format: image/fits
     # access_url format is still under discussion/review:
-    datalink_url_fmt: "https://usdf-rsp.slac.stanford.edu/api/datalink/links?ID=butler%3A//LATISS/{id}"
+    datalink_url_fmt: "https://usdf-rsp.slac.stanford.edu/api/datalink/links?ID=butler%3A//embargo/{id}"
   calexp:
     dataproduct_type: image
     dataproduct_subtype: lsst.calexp
@@ -27,7 +27,7 @@ dataset_types:
     o_ucd: phot.count
     access_format: image/fits
     # access_url format is still under discussion/review:
-    datalink_url_fmt: "https://usdf-rsp.slac.stanford.edu/api/datalink/links?ID=butler%3A//LATISS/{id}"
+    datalink_url_fmt: "https://usdf-rsp.slac.stanford.edu/api/datalink/links?ID=butler%3A//embargo/{id}"
   quickLookExp:
     dataproduct_type: image
     dataproduct_subtype: lsst.quickLookExp
@@ -36,7 +36,7 @@ dataset_types:
     o_ucd: phot.count
     access_format: image/fits
     # access_url format is still under discussion/review:
-    datalink_url_fmt: "https://usdf-rsp.slac.stanford.edu/api/datalink/links?ID=butler%3A//LATISS/{id}"
+    datalink_url_fmt: "https://usdf-rsp.slac.stanford.edu/api/datalink/links?ID=butler%3A//embargo/{id}"
 extra_columns:
   lsst_visit:
     template: "{visit}"

--- a/python/lsst/dax/obscore/obscore_exporter.py
+++ b/python/lsst/dax/obscore/obscore_exporter.py
@@ -329,7 +329,8 @@ class ObscoreExporter:
         if not collections:
             collections = ...
 
-        registry = self.butler.registry
+        # Have to use non-public Registry interface.
+        registry = self.butler._registry
         assert isinstance(registry, SqlRegistry), "Registry must be SqlRegistry"
         backend = SqlQueryBackend(registry._db, registry._managers)
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -93,7 +93,7 @@ class TestCase(unittest.TestCase):
 
         butler = self.make_butler()
 
-        config = ExporterConfig(version=0, obs_collection="", dataset_types=[], facility_name="FACILITY")
+        config = ExporterConfig(version=0, obs_collection="", dataset_types={}, facility_name="FACILITY")
         xprtr = ObscoreExporter(butler, config)
         self.assertCountEqual(xprtr.schema.names, _STANDARD_COLUMNS)
 
@@ -102,7 +102,7 @@ class TestCase(unittest.TestCase):
             version=0,
             obs_collection="",
             extra_columns={"c1": 1, "c2": "string", "c3": {"template": "{calib_level}", "type": "float"}},
-            dataset_types=[],
+            dataset_types={},
             facility_name="FACILITY",
         )
         xprtr = ObscoreExporter(butler, config)


### PR DESCRIPTION
We have updated datalink URI in obscore configuration on live embargo database, this commit updates usdf-embargo-live.yaml to reflect those changes.