### PR TITLE
DM-51269: Add fallback instruments to single-instrument ObsCore configs

### DIFF
--- a/configs/ci_hsc_gen3.yaml
+++ b/configs/ci_hsc_gen3.yaml
@@ -2,6 +2,7 @@
 facility_name: Subaru
 obs_collection: LSST.CI
 collections: ["HSC/runs/ci_hsc"]
+fallback_instrument: HSC
 dataset_types:
   raw:
     dataproduct_type: image

--- a/configs/dc2.yaml
+++ b/configs/dc2.yaml
@@ -2,6 +2,7 @@ facility_name: Rubin-LSST
 obs_collection: LSST.DC2
 collections: ["2.2i/runs/DP0.1"]
 use_butler_uri: false
+fallback_instrument: LSSTCam-imSim
 dataset_types:
   raw:
     dataproduct_type: image

--- a/configs/dp02.yaml
+++ b/configs/dp02.yaml
@@ -1,6 +1,7 @@
 facility_name: Rubin-LSST
 obs_collection: LSST.DP02
 collections: ["2.2i/runs/DP0.2"]
+fallback_instrument: LSSTCam-imSim
 use_butler_uri: false
 dataset_types:
   raw:

--- a/configs/dp1.yaml
+++ b/configs/dp1.yaml
@@ -4,6 +4,7 @@ facility_map:
 obs_collection: LSST.DP1
 collections: ["LSSTComCam/DP1"]
 use_butler_uri: false
+fallback_instrument: LSSTComCam
 dataset_types:
   raw:
     dataproduct_type: image


### PR DESCRIPTION
Requires lsst/daf_butler#1216

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
