### PR TITLE
DM-54169: Add configuration for prompt data products

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Update pip/wheel infrastructure
         run: |
           python -m pip install --upgrade pip
-          pip install wheel uv setuptools
+          pip install wheel uv 'setuptools<82.0.0'
 
       - name: Install dependencies
         run: |

--- a/configs/dp1.yaml
+++ b/configs/dp1.yaml
@@ -105,4 +105,4 @@ origin:
   citation: 10.71929/rubin/2570308
   reference_url: "https://dp1.lsst.io"
   article: 10.71929/rubin/2570536
-  title: "Legacy Survey of Date and Time Data Preview 1"
+  title: "Legacy Survey of Space and Time Data Preview 1"

--- a/configs/prompt.yaml
+++ b/configs/prompt.yaml
@@ -1,0 +1,72 @@
+facility_name: Rubin:Simonyi
+facility_map:
+  LSSTCam: "Rubin:Simonyi"
+obs_collection: LSST.Prompt
+collections: ["Prompt/Available"]
+use_butler_uri: false
+fallback_instrument: LSSTCam
+obs_publisher_did_fmt: "ivo://org.rubinobs/usdac/lsst-prompt?repo=prompt&id={id}"
+dataset_types:
+  preliminary_visit_image:
+    dataproduct_type: image
+    dataproduct_subtype: lsst.preliminary_visit_image
+    calib_level: 2
+    obs_id_fmt: "{records[visit].name}"
+    o_ucd: phot.flux.density
+    access_format: "application/x-votable+xml;content=datalink"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-prompt%3Frepo%3Dprompt%26id%3D{id}"
+    s_xel: [4072, 4000]
+    extra_columns:
+      obs_title:
+        template: "{dataset_type} - {band} - {records[visit].name}-{records[detector].full_name} {records[visit].timespan.begin.utc.isot}Z"
+  difference_image:
+    dataproduct_type: image
+    dataproduct_subtype: lsst.difference_image
+    calib_level: 3
+    obs_id_fmt: "{records[visit].name}"
+    o_ucd: phot.flux.density
+    access_format: "application/x-votable+xml;content=datalink"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-prompt%3Frepo%3Dprompt%26id%3D{id}"
+    s_xel: [4072, 4000]
+    extra_columns:
+      obs_title:
+        template: "{dataset_type} - {band} - {records[visit].name}-{records[detector].full_name} {records[visit].timespan.begin.utc.isot}Z"
+extra_columns:
+  lsst_visit:
+    template: "{visit}"
+    type: "int"
+    doc: Visit or exposure identifier
+  lsst_detector:
+    template: "{detector}"
+    type: "int"
+    doc: Detector number of this observation
+  lsst_tract:
+    template: "{tract}"
+    type: "int"
+    doc: Tract within a skymap
+  lsst_patch:
+    template: "{patch}"
+    type: "int"
+    doc: Patch within a tract
+  lsst_band:
+    template: "{band}"
+    type: "string"
+    doc: Wavelength band for this observation
+  lsst_filter:
+    template: "{physical_filter}"
+    type: "string"
+    doc: Physical filter name for this observation
+spectral_ranges:
+  "u": [300.0e-9, 393.2e-9]
+  "g": [402.6e-9, 548.3e-9]
+  "r": [551.0e-9, 689.1e-9]
+  "i": [693.6e-9, 818.8e-9]
+  "z": [819.2e-9, 920.1e-9]
+  "y": [927.8e-9, 1100.0e-9]
+origin:
+  publisher: "NSF-DOE Vera C. Rubin Observatory US Data Access Center"
+  publication_date: TBD
+  citation: TBD
+  reference_url: "https://lsst.io"
+  article: TBD
+  title: "Legacy Survey of Space and Time Prompt Products"

--- a/doc/changes/DM-54169.feature
+++ b/doc/changes/DM-54169.feature
@@ -1,0 +1,1 @@
+Added an SIAv2 configuration for Prompt Data Products.


### PR DESCRIPTION
Added a minimal SIAv2 configuration for Prompt Data Products, including only the image types `raw`, `preliminary_visit_image` and `difference_image`.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
