### PR TITLE
DM-55279: Add ObscoreExporter.iter_records() public API

### DIFF
--- a/doc/changes/DM-55279.api.rst
+++ b/doc/changes/DM-55279.api.rst
@@ -1,0 +1,2 @@
+Added ``ObscoreExporter.iter_records()`` as a public row-oriented API for callers that need ObsCore records directly instead of file exports.
+The method reuses the existing internal batch generation path and yields plain Python dictionaries.

--- a/python/lsst/dax/obscore/obscore_exporter.py
+++ b/python/lsst/dax/obscore/obscore_exporter.py
@@ -262,6 +262,23 @@ class ObscoreExporter:
             config, schema, universe, spatial_plugins, self._derived_region_factory
         )
 
+    def iter_records(self, limit: int | None = None) -> Iterator[dict[str, Any]]:
+        """Iterate over ObsCore records as Python row dictionaries.
+
+        Parameters
+        ----------
+        limit : `int` or `None`, optional
+            Maximum number of records to return. If `None`, yield all matching
+            records.
+
+        Yields
+        ------
+        record : `dict` [`str`, `~typing.Any`]
+            One ObsCore record, keyed by column name.
+        """
+        for record_batch, _ in self._make_record_batches(self.config.batch_size, limit=limit):
+            yield from record_batch.to_pylist()
+
     def to_parquet(self, output: str) -> None:
         """Export Butler datasets as ObsCore Data Model in parquet format.
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -155,6 +155,72 @@ class TestCase(unittest.TestCase, DaxObsCoreTestMixin):
         for value in _to_python("s_region"):
             self.assertTrue(value.startswith("POLYGON "))
 
+    def test_iter_records(self):
+        """Test row-oriented ObsCore record iteration."""
+        butler = self.make_butler()
+        self.enterContext(butler)
+        butler.import_(filename=os.path.join(TESTDIR, "data", "hsc_gen3.yaml"), without_datastore=True)
+
+        config = self.make_export_config()
+        xprtr = ObscoreExporter(butler, config)
+        records = list(xprtr.iter_records())
+
+        self.assertEqual(len(records), 35)
+        self.assertEqual({frozenset(record) for record in records}, {frozenset(xprtr.schema.names)})
+        self.assertEqual({record["facility_name"] for record in records}, {"Subaru"})
+        self.assertEqual({record["obs_collection"] for record in records}, {"obs-collection"})
+        self.assertEqual({record["dataproduct_type"] for record in records}, {"image"})
+        self.assertEqual(
+            {record["dataproduct_subtype"] for record in records}, {"lsst.calexp", "lsst.deepCoadd"}
+        )
+        self.assertEqual({record["calib_level"] for record in records}, {2, 3})
+        self.assertEqual({record["instrument_name"] for record in records}, {"HSC", None})
+        self.assertEqual({record["em_filter_name"] for record in records}, {"i", "r"})
+        self.assertEqual({record["day_obs"] for record in records}, {20130617, 20131102, None})
+        for record in records:
+            self.assertTrue(record["s_region"].startswith("POLYGON "))
+
+    def test_iter_records_multiple_dataset_types(self):
+        """Record iteration can return multiple configured dataset types."""
+        butler = self.make_butler()
+        self.enterContext(butler)
+        butler.import_(filename=os.path.join(TESTDIR, "data", "hsc_gen3.yaml"), without_datastore=True)
+
+        config = self.make_export_config()
+        config.select_dataset_types(["_mock_calexp"])
+        xprtr = ObscoreExporter(butler, config)
+        calexp_records = list(xprtr.iter_records())
+
+        config = self.make_export_config()
+        config.select_dataset_types(["_mock_deepCoadd"])
+        xprtr = ObscoreExporter(butler, config)
+        deep_coadd_records = list(xprtr.iter_records())
+
+        config = self.make_export_config()
+        config.select_dataset_types(["_mock_calexp", "_mock_deepCoadd"])
+        xprtr = ObscoreExporter(butler, config)
+        combined_records = list(xprtr.iter_records())
+
+        self.assertGreater(len(calexp_records), 0)
+        self.assertGreater(len(deep_coadd_records), 0)
+        self.assertEqual(len(combined_records), len(calexp_records) + len(deep_coadd_records))
+        self.assertEqual(
+            {record["dataproduct_subtype"] for record in combined_records},
+            {"lsst.calexp", "lsst.deepCoadd"},
+        )
+
+    def test_iter_records_limit(self):
+        """A limit caps the number of iterated records."""
+        butler = self.make_butler()
+        self.enterContext(butler)
+        butler.import_(filename=os.path.join(TESTDIR, "data", "hsc_gen3.yaml"), without_datastore=True)
+
+        config = self.make_export_config()
+        xprtr = ObscoreExporter(butler, config)
+
+        self.assertEqual(len(list(xprtr.iter_records(limit=5))), 5)
+        self.assertEqual(list(xprtr.iter_records(limit=0)), [])
+
     def test_export_csv(self):
         """Test CSV export method"""
         butler = self.make_butler()


### PR DESCRIPTION
Add ``ObscoreExporter.iter_records()`` as a public row-oriented API for callers that need ObsCore records directly instead of file exports. 
The method reuses the existing internal batch generation path and yields plain Python dictionaries.

## Checklist

- [ X ] ran Jenkins
- [ X ] added a release note for user-visible changes to `doc/changes`

