### PR TITLE
DM-55613: Some cleanups for DP2 ObsCore

### DIFF
--- a/configs/dp1.yaml
+++ b/configs/dp1.yaml
@@ -5,7 +5,7 @@ obs_collection: LSST.DP1
 collections: ["LSSTComCam/DP1"]
 use_butler_uri: false
 fallback_instrument: LSSTComCam
-obs_publisher_did_fmt: "ivo://org.rubinobs/usdac/lsst-dp1?repo=dp1&id={id}"
+obs_publisher_did_fmt: "ivo://org.rubinobs/usdac/lsst-dp1/datasets?repo=dp1&id={id}"
 dataset_types:
   raw:
     dataproduct_type: image
@@ -14,7 +14,7 @@ dataset_types:
     obs_id_fmt: "{records[exposure].obs_id}"
     o_ucd: phot.count
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Flsst-dp1%2Fdatasets%3Frepo%3Ddp1%26id%3D{id}"
     s_xel: [4608, 4096]
     extra_columns:
       obs_title:
@@ -26,7 +26,7 @@ dataset_types:
     obs_id_fmt: "{records[visit].name}"
     o_ucd: phot.flux.density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Flsst-dp1%2Fdatasets%3Frepo%3Ddp1%26id%3D{id}"
     s_xel: [4072, 4000]
     extra_columns:
       obs_title:
@@ -38,7 +38,7 @@ dataset_types:
     obs_id_fmt: "{skymap}-{tract}-{patch}"
     o_ucd: phot.flux.density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Flsst-dp1%2Fdatasets%3Frepo%3Ddp1%26id%3D{id}"
     s_xel: [3400, 3400]
     extra_columns:
       obs_title:
@@ -50,7 +50,7 @@ dataset_types:
     obs_id_fmt: "{skymap}-{tract}-{patch}"
     o_ucd: phot.flux_density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Flsst-dp1%2Fdatasets%3Frepo%3Ddp1%26id%3D{id}"
     s_xel: [3400, 3400]
     extra_columns:
       obs_title:
@@ -62,7 +62,7 @@ dataset_types:
     obs_id_fmt: "{records[visit].name}"
     o_ucd: phot.flux.density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Flsst-dp1%2Fdatasets%3Frepo%3Ddp1%26id%3D{id}"
     s_xel: [4072, 4000]
     extra_columns:
       obs_title:

--- a/configs/dp2.yaml
+++ b/configs/dp2.yaml
@@ -101,7 +101,7 @@ spectral_ranges:
   "y": [927.8e-9, 1100.0e-9]
 origin:
   publisher: "NSF-DOE Vera C. Rubin Observatory US Data Access Center"
-  publication_date: 2026-06-30
+  publication_date: 2026-07-27
   citation: 10.71929/rubin/3382528
   reference_url: "https://dp2.lsst.io"
   article: 10.71929/rubin/3377440

--- a/configs/dp2.yaml
+++ b/configs/dp2.yaml
@@ -5,7 +5,7 @@ obs_collection: LSST.DP2
 collections: ["LSSTCam/runs/DRP/DP2"]
 use_butler_uri: false
 fallback_instrument: LSSTCam
-obs_publisher_did_fmt: "ivo://org.rubinobs/usdac/lsst-dp2?repo=dp2&id={id}"
+obs_publisher_did_fmt: "ivo://org.rubinobs/usdac/lsst-dp2/datasets?repo=dp2&id={id}"
 dataset_types:
   raw:
     dataproduct_type: image

--- a/configs/dp2.yaml
+++ b/configs/dp2.yaml
@@ -102,7 +102,7 @@ spectral_ranges:
 origin:
   publisher: "NSF-DOE Vera C. Rubin Observatory US Data Access Center"
   publication_date: 2026-06-30
-  citation:
+  citation: 10.71929/rubin/3382528
   reference_url: "https://dp2.lsst.io"
-  article:
+  article: 10.71929/rubin/3377440
   title: "Legacy Survey of Space and Time Data Preview 2"

--- a/configs/dp2.yaml
+++ b/configs/dp2.yaml
@@ -14,7 +14,7 @@ dataset_types:
     obs_id_fmt: "{records[exposure].obs_id}"
     o_ucd: phot.count
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2fusdac%2Flsst-dp2%2Fdatasets%3Frepo%3Ddp2%26id%3D{id}"
     s_xel: [4608, 4096]
     extra_columns:
       obs_title:
@@ -26,7 +26,7 @@ dataset_types:
     obs_id_fmt: "{records[visit].name}"
     o_ucd: phot.flux.density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2fusdac%2Flsst-dp2%2Fdatasets%3Frepo%3Ddp2%26id%3D{id}"
     s_xel: [4072, 4000]
     extra_columns:
       obs_title:
@@ -38,7 +38,7 @@ dataset_types:
     obs_id_fmt: "{skymap}-{tract}-{patch}"
     o_ucd: phot.flux.density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2fusdac%2Flsst-dp2%2Fdatasets%3Frepo%3Ddp2%26id%3D{id}"
     s_xel: [3300, 3300]
     extra_columns:
       obs_title:
@@ -50,7 +50,7 @@ dataset_types:
     obs_id_fmt: "{skymap}-{tract}-{patch}"
     o_ucd: phot.flux.density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2fusdac%2Flsst-dp2%2Fdatasets%3Frepo%3Ddp2%26id%3D{id}"
     s_xel: [3300, 3300]
     extra_columns:
       obs_title:
@@ -62,7 +62,7 @@ dataset_types:
     obs_id_fmt: "{records[visit].name}"
     o_ucd: phot.flux.density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2fusdac%2Flsst-dp2%2Fdatasets%3Frepo%3Ddp2%26id%3D{id}"
     s_xel: [4072, 4000]
     extra_columns:
       obs_title:

--- a/configs/edp2.yaml
+++ b/configs/edp2.yaml
@@ -54,7 +54,7 @@ spectral_ranges:
 origin:
   publisher: "NSF-DOE Vera C. Rubin Observatory US Data Access Center"
   publication_date: 2026-06-30
-  citation:
+  citation: 10.71929/rubin/3382528
   reference_url: "https://dp2.lsst.io"
-  article:
+  article: 10.71929/rubin/3377440
   title: "Legacy Survey of Space and Time Data Preview 2"

--- a/configs/edp2.yaml
+++ b/configs/edp2.yaml
@@ -14,7 +14,7 @@ dataset_types:
     obs_id_fmt: "{skymap}-{tract}-{patch}"
     o_ucd: phot.flux.density
     access_format: "application/x-votable+xml;content=datalink"
-    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
+    datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2fusdac%2Flsst-dp2%2Fdatasets%3Frepo%3Ddp2%26id%3D{id}"
     s_xel: [3300, 3300]
     extra_columns:
       obs_title:

--- a/configs/edp2.yaml
+++ b/configs/edp2.yaml
@@ -5,7 +5,7 @@ obs_collection: LSST.DP2
 collections: ["LSSTCam/runs/DRP/DP2"]
 use_butler_uri: false
 fallback_instrument: LSSTCam
-obs_publisher_did_fmt: "ivo://org.rubinobs/usdac/lsst-dp2?repo=dp2&id={id}"
+obs_publisher_did_fmt: "ivo://org.rubinobs/usdac/lsst-dp2/datasets?repo=dp2&id={id}"
 dataset_types:
   deep_coadd:
     dataproduct_type: image

--- a/configs/edp2.yaml
+++ b/configs/edp2.yaml
@@ -53,7 +53,7 @@ spectral_ranges:
   "y": [927.8e-9, 1100.0e-9]
 origin:
   publisher: "NSF-DOE Vera C. Rubin Observatory US Data Access Center"
-  publication_date: 2026-06-30
+  publication_date: 2026-07-27
   citation: 10.71929/rubin/3382528
   reference_url: "https://dp2.lsst.io"
   article: 10.71929/rubin/3377440


### PR DESCRIPTION
* Adds dataset and paper DOI for DP2
* Sets correct release date for DP2
* Changes IVOIDs to use `/usdac/lsst-dp2/datasets`


## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
